### PR TITLE
BSI Sources 2023 & NGINX Update

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # nginx Configuration
 # Docker Container and Image related Configuration
-NGINX_IMAGE_VERSION=1.21.1-alpine
+NGINX_IMAGE_VERSION=1.25.1-alpine-slim
 NGINX_IMAGE_NAME=custom-nginx
 NGINX_CONTAINER_NAME=nginx
 # Docker Compose Configuration

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -6,8 +6,8 @@ We as members, contributors, and leaders pledge to make participation in our
 community a harassment-free experience for everyone, regardless of age, body
 size, visible or invisible disability, ethnicity, sex characteristics, gender
 identity and expression, level of experience, education, socio-economic status,
-nationality, personal appearance, race, religion, or sexual identity
-and orientation.
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
 
 We pledge to act and interact in ways that contribute to an open, welcoming,
 diverse, inclusive, and healthy community.
@@ -22,17 +22,17 @@ community include:
 * Giving and gracefully accepting constructive feedback
 * Accepting responsibility and apologizing to those affected by our mistakes,
   and learning from the experience
-* Focusing on what is best not just for us as individuals, but for the
-  overall community
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
 
 Examples of unacceptable behavior include:
 
-* The use of sexualized language or imagery, and sexual attention or
-  advances of any kind
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
 * Trolling, insulting or derogatory comments, and personal or political attacks
 * Public or private harassment
-* Publishing others' private information, such as a physical or email
-  address, without their explicit permission
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
 * Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
@@ -82,15 +82,15 @@ behavior was inappropriate. A public apology may be requested.
 
 ### 2. Warning
 
-**Community Impact**: A violation through a single incident or series
-of actions.
+**Community Impact**: A violation through a single incident or series of
+actions.
 
 **Consequence**: A warning with consequences for continued behavior. No
 interaction with the people involved, including unsolicited interaction with
 those enforcing the Code of Conduct, for a specified period of time. This
 includes avoiding interactions in community spaces as well as external channels
-like social media. Violating these terms may lead to a temporary or
-permanent ban.
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
 
 ### 3. Temporary Ban
 
@@ -106,23 +106,27 @@ Violating these terms may lead to a permanent ban.
 ### 4. Permanent Ban
 
 **Community Impact**: Demonstrating a pattern of violation of community
-standards, including sustained inappropriate behavior,  harassment of an
+standards, including sustained inappropriate behavior, harassment of an
 individual, or aggression toward or disparagement of classes of individuals.
 
-**Consequence**: A permanent ban from any sort of public interaction within
-the community.
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
 
 ## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage],
-version 2.0, available at
-https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
 
-Community Impact Guidelines were inspired by [Mozilla's code of conduct
-enforcement ladder](https://github.com/mozilla/diversity).
-
-[homepage]: https://www.contributor-covenant.org
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
 
 For answers to common questions about this code of conduct, see the FAQ at
-https://www.contributor-covenant.org/faq. Translations are available at
-https://www.contributor-covenant.org/translations.
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ No more need to install these programs on your own or write complex nginx config
 ## Features
 
 - i18n (Internationalization) for German and English.
-- highly secure TLS configurations for nginx (see [BSI sources](#security-sources))
+- highly secure TLS configurations for nginx (see [sources](#security-sources))
 - pre-configured but also customizable nginx
-- modern deployment with docker containers and docker-compose
+- modern deployment with docker containers and docker compose
 - automatically renewal of certificates
 - integrated history functions for certificate creation/update/revocation
 - possibility to inform own programs/scripts at a change of certificates (see "Own Integrations" in Wiki)
@@ -55,7 +55,18 @@ Furthermore, the usage of these scripts is quite easy.
 
 * Overview: https://www.bsi.bund.de/DE/Themen/Oeffentliche-Verwaltung/Mindeststandards/TLS-Protokoll/TLS-Protokoll_node.html
 * Changelog: https://www.bsi.bund.de/DE/Themen/Oeffentliche-Verwaltung/Mindeststandards/TLS-Protokoll/Aenderungsuebersicht_MST_TLS/Aenderungsuebersicht_TLS_node.html
-* https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102-2.pdf?__blob=publicationFile (Version 2021-01)
-* https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR03116/BSI-TR-03116-4.pdf?__blob=publicationFile (Version 23.02.2021)
-* https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Mindeststandards/Hilfsdokument_Mindeststandard_BSI_TLS_Version_2_2.pdf?__blob=publicationFile (Version 2.2 of 03.05.2021)
-* https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Mindeststandards/Mindeststandard_BSI_TLS_Version_2_2.pdf?__blob=publicationFile (Version 2.2 of 03.05.2021)
+* TR-02102: https://www.bsi.bund.de/DE/Themen/Unternehmen-und-Organisationen/Standards-und-Zertifizierung/Technische-Richtlinien/TR-nach-Thema-sortiert/tr02102/tr02102_node.html
+* TR-03116: https://www.bsi.bund.de/DE/Themen/Unternehmen-und-Organisationen/Standards-und-Zertifizierung/Technische-Richtlinien/TR-nach-Thema-sortiert/tr03116/TR-03116_node.html
+
+#### Documents
+
+* APP.3.2 Webserver: https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Grundschutz/IT-GS-Kompendium_Einzel_PDFs_2023/06_APP_Anwendungen/APP_3_2_Webserver_Edition_2023.pdf?__blob=publicationFile&v=3 (Edition 2023)
+* TR-02102-1 Kryptografische Verfahren - Empfehlungen und Schlüssellängen: https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102.pdf?__blob=publicationFile&v=8 (Version 2023-01, Stand: 09. Januar 2023)
+* TR-02102-2 Kryptografische Verfahren - Verwendung von Transport Layer Security (TLS): https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102-2.pdf?__blob=publicationFile (Version 2023-01)
+* Mindeststandard des BSI zur Verwendung von Transport Layer Security: https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Mindeststandards/Mindeststandard_BSI_TLS_Version_2_4.pdf?__blob=publicationFile&v=4 (Version 2.4 vom 25.05.2023)
+* Hilfsdokument zum Mindeststandard des BSI zur Verwendung von Transport Layer Security V2.4: https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Mindeststandards/Hilfsdokument_Mindeststandard_BSI_TLS_Version_2_4.pdf?__blob=publicationFile&v=3 (Version 2.4 vom 25.05.2023)
+
+#### Information for projects for the German Government
+
+* TR-03116-4 Kryptografische Vorgaben für Projekte der Bundesregierung - Kommunikationsverfahren in Anwendungen: https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR03116/BSI-TR-03116-4.pdf?__blob=publicationFile (Version 07.03.2023)
+* TLS-Checkliste 2023: https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR03116/TLS-Checkliste.pdf?__blob=publicationFile&v=5 (Stand 2023, Datum: 7. März 2023)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   certbot:
     build:

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -22,8 +22,8 @@ ARG HTTP_PORT
 
 RUN apk add --no-cache bash \
     && apk add --no-cache --virtual .build-deps openssl \
-    # https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102-2.pdf?__blob=publicationFile&v=2#page=16
-    ## DH 2000 Bit: 2022
-    && openssl dhparam -out /etc/nginx/ssl-dhparams.pem 2000 \
+    # https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102-2.pdf?__blob=publicationFile&v=2#page=17
+    ## DH 3000 Bit: 2029+
+    && openssl dhparam -out /etc/nginx/ssl-dhparams.pem 3000 \
     && apk del .build-deps \
     && ./build_nginx_conf.sh

--- a/nginx/conf.d/https.template
+++ b/nginx/conf.d/https.template
@@ -1,8 +1,10 @@
 include /etc/nginx/upstreams/{{CERTIFICATE_NAME}}.conf*;
 
 server {
-    listen {{HTTPS_PORT}} ssl;
-    listen [::]:{{HTTPS_PORT}} ssl;
+    listen {{HTTPS_PORT}};
+    listen [::]:{{HTTPS_PORT}};
+
+    http2 on;
 
     server_name {{DOMAIN_NAMES}};
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,7 +1,7 @@
 user  nginx;
 worker_processes  auto;
 
-error_log  /var/log/nginx/error.log warn;
+error_log  /var/log/nginx/error.log notice;
 pid        /var/run/nginx.pid;
 
 
@@ -21,8 +21,11 @@ http {
     access_log  /var/log/nginx/access.log  main;
 
     sendfile        on;
+    #tcp_nopush     on;
 
     keepalive_timeout  65;
+
+    #gzip    on;
 
     include /etc/nginx/certbot.conf;
     include /etc/nginx/conf.d/*.conf;

--- a/nginx/options/ssl.conf
+++ b/nginx/options/ssl.conf
@@ -1,35 +1,36 @@
 # https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102-2.pdf?__blob=publicationFile&v=2#page=6
 ssl_protocols TLSv1.2 TLSv1.3;
 
-# https://www.openssl.org/docs/man1.1.1/man1/ciphers.html
-# SSL_CTX_set_cipher_list from openssl library is limited to 255 chars for cipher-list-string
-# highest secure are taken (with PFS but without PSK, because PSK is not supported by openssl for recommended algorithms), for all recommended ciphers split into three categories look at the following three paragraphs
-ssl_ciphers "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384:TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384:TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384:TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384:DHE-RSA-AES256-SHA256:TLS_DHE_RSA_WITH_AES_256_GCM_SHA384";
+# https://www.openssl.org/docs/man3.0/man1/openssl-ciphers.html
+## Combined supported and recommended Ciphers from TLS v1.2 and TLS v1.3
+ssl_ciphers "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384";
 
-# TLSv1.2: https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102-2.pdf?__blob=publicationFile&v=2#page=7
-## (EC)DHE: 2027+ -> Most recommended because PFS (Perfect Forward Secrecy) support
-#ssl_ciphers "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384:TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256:TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384:TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256:TLS_ECDHE_ECDSA_WITH_AES_256_CCM:TLS_ECDHE_ECDSA_WITH_AES_128_CCM:TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384:TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256:TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384:TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256:TLS_DHE_DSS_WITH_AES_128_CBC_SHA256:TLS_DHE_DSS_WITH_AES_256_CBC_SHA256:TLS_DHE_DSS_WITH_AES_128_GCM_SHA256:TLS_DHE_DSS_WITH_AES_256_GCM_SHA384:TLS_DHE_RSA_WITH_AES_256_CBC_SHA256:TLS_DHE_RSA_WITH_AES_128_CBC_SHA256:TLS_DHE_RSA_WITH_AES_256_GCM_SHA384:TLS_DHE_RSA_WITH_AES_128_GCM_SHA256:TLS_DHE_RSA_WITH_AES_256_CCM:TLS_DHE_RSA_WITH_AES_128_CCM";
+# TLS v1.2: https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102-2.pdf?__blob=publicationFile&v=2#page=8
+## (EC)DHE: 2029+ -> Most recommended because PFS (Perfect Forward Secrecy) support
+## CBC Cipher-Suites are not recommended without the "encrypt_then_mac" (RFC7366) extension
+#ssl_ciphers "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384";
+
+# TLS v1.2: https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102-2.pdf?__blob=publicationFile&v=2#page=9
+## (EC)DH: 2026 -> If PFS is not possible/supported
+## CBC Cipher-Suites are not recommended without the "encrypt_then_mac" (RFC7366) extension
+## Recommended Ciphers are not supported by current OpenSSL version
+
+# TLS v1.2: https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102-2.pdf?__blob=publicationFile&v=2#page=10
+## TLS_*_PSK_*: 2029+
+## TLS_RSA_PSK_*: 2026 -> do not give PFS (less recommended)
+## CBC Cipher-Suites are not recommended without the "encrypt_then_mac" (RFC7366) extension
+## Recommended Ciphers are not supported by current OpenSSL version
 
 # TLSv1.3 https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102-2.pdf?__blob=publicationFile&v=2#page=8
-## (EC)DH: 2026 -> Recommended, when PFS not possible
-## Warning: Possible not supported by openssl lib
-#ssl_ciphers "TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384:TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256:TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384:TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256:TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384:TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256:TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384:TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256:TLS_DH_DSS_WITH_AES_256_CBC_SHA256:TLS_DH_DSS_WITH_AES_128_CBC_SHA256:TLS_DH_DSS_WITH_AES_256_GCM_SHA384:TLS_DH_DSS_WITH_AES_128_GCM_SHA256:TLS_DH_RSA_WITH_AES_256_CBC_SHA256:TLS_DH_RSA_WITH_AES_128_CBC_SHA256:TLS_DH_RSA_WITH_AES_256_GCM_SHA384:TLS_DH_RSA_WITH_AES_128_GCM_SHA256";
+## 2029+
+#ssl_ciphers "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384";
 
-# PSK: https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102-2.pdf?__blob=publicationFile&v=2#page=9
-# Recommended ciphers with Pre-shared Key (PSK)
-## TLS-ECDHE-PSK-* & TLS-DHE-PSK-*: 2027+
-## TLD-RSA-PSK-*: 2026
-## Warning: Not supported by openssl lib
-#ssl_ciphers "TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA384:TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA256:TLS_ECDHE_PSK_WITH_AES_256_GCM_SHA384:TLS_ECDHE_PSK_WITH_AES_128_GCM_SHA256:TLS_ECDHE_PSK_WITH_AES_128_CCM_SHA256:TLS_DHE_PSK_WITH_AES_256_CBC_SHA384:TLS_DHE_PSK_WITH_AES_128_CBC_SHA256:TLS_DHE_PSK_WITH_AES_256_GCM_SHA384:TLS_DHE_PSK_WITH_AES_128_GCM_SHA256:TLS_DHE_PSK_WITH_AES_256_CCM:TLS_DHE_PSK_WITH_AES_128_CCM:TLS_RSA_PSK_WITH_AES_256_CBC_SHA384:TLS_RSA_PSK_WITH_AES_128_CBC_SHA256:TLS_RSA_PSK_WITH_AES_256_GCM_SHA384:TLS_RSA_PSK_WITH_AES_128_GCM_SHA256";
-
-# TLSv1.3: https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102-2.pdf?__blob=publicationFile&v=2#page=15
-## *: 2027+
-ssl_conf_command Ciphersuites "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_AES_128_CCM_SHA256";
 # https://weakdh.org/sysadmin.html#nginx
 ssl_prefer_server_ciphers on;
 
-# TLSv1.2: https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102-2.pdf?__blob=publicationFile&v=2#page=10
+# TLSv1.2: https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102-2.pdf?__blob=publicationFile&v=2#page=11
 # TLSv1.3: https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102-2.pdf?__blob=publicationFile&v=2#page=14
-## *: 2027+
-## This is the only supported by openssl lib
-ssl_ecdh_curve "secp384r1";
+# TLSv1.3: https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102-2.pdf?__blob=publicationFile&v=2#page=18
+## *: 2029+
+## More supported (supported_groups_default) (https://github.com/openssl/openssl/blob/openssl-3.0/ssl/t1_lib.c) -> recommended brainpool-groups not exists
+ssl_ecdh_curve "ffdhe4096";


### PR DESCRIPTION
- Update NGINX to 1.25.1
- Use smaller (slim) NGINX Dockerfile
- Update Code of Conduct
- Remove deprecated Docker Compose file version tag
- Update DH Params size
- Update SSL-Config according to latest (2023) BSI recommendations
- https.template -> remove deprecated ssl arguments and use https2 directive
- Update nginx.conf